### PR TITLE
@JvmStatic on get operator for cleaner java code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ FontBinder **automatically caches used typefaces** to avoid recreating them in t
 
 ```java
 // Java
-mTextView.setTypeface(FontBinder.INSTANCE.get("FontFileNameWithoutExtension"));
+mTextView.setTypeface(FontBinder.get("FontFileNameWithoutExtension"));
 ```
 ```kotlin
 // Kotlin

--- a/fontbinder/src/main/java/com/github/nitrico/fontbinder/FontBinder.kt
+++ b/fontbinder/src/main/java/com/github/nitrico/fontbinder/FontBinder.kt
@@ -38,7 +38,7 @@ object FontBinder {
 
     fun add(fontName: String, fontFilename: String) = fontMapping.put(fontName, fontFilename)
 
-    operator fun get(fontName: String): Typeface? {
+    @JvmStatic operator fun get(fontName: String): Typeface? {
         val fontFilename = fontMapping[fontName]
         if (fontFilename == null) {
             Log.e(TAG, "Couldn't find font $fontName.")


### PR DESCRIPTION
Just added @JvmStatic to the get operator, so in Java there's no need to call it using INSTANCE.
